### PR TITLE
Fix limit on the number of nodes and wallets in scripts

### DIFF
--- a/create_wallets.sh
+++ b/create_wallets.sh
@@ -17,16 +17,15 @@ correct_command() {
 create_wallets() {
     for (( i=1; i <= $wallets_number; i++ ))
     do
-    	pin="000$i"
-    	if (( $i < 10 ))
+	pin="000$i"
+	if (( $i < 10 ))
 	then
 		pin="000$i"
 	else
 		pin="00$i"
 	fi
 	
-	echo $pin
-        echo "Creating $i wallet with pin $pin"
+	echo "Creating $i wallet with pin $pin"
         mkdir -p "wallet_$i"
         cd wallet_$i
         cmd_tool=$(correct_command)

--- a/create_wallets.sh
+++ b/create_wallets.sh
@@ -17,13 +17,8 @@ correct_command() {
 create_wallets() {
     for (( i=1; i <= $wallets_number; i++ ))
     do
-	pin="000$i"
-	if (( $i < 10 ))
-	then
-		pin="000$i"
-	else
-		pin="00$i"
-	fi
+
+    pin=$(seq -w 9999 | head -n $i | tail -1)
 	
 	echo "Creating $i wallet with pin $pin"
         mkdir -p "wallet_$i"

--- a/create_wallets.sh
+++ b/create_wallets.sh
@@ -17,13 +17,22 @@ correct_command() {
 create_wallets() {
     for (( i=1; i <= $wallets_number; i++ ))
     do
-        echo "Creating $i wallet with pin 000$i"
+    	pin="000$i"
+    	if (( $i < 10 ))
+	then
+		pin="000$i"
+	else
+		pin="00$i"
+	fi
+	
+	echo $pin
+        echo "Creating $i wallet with pin $pin"
         mkdir -p "wallet_$i"
         cd wallet_$i
         cmd_tool=$(correct_command)
         # echo $cmd_tool
-        $cmd_tool tagionwallet --generate-wallet --questions q1,q2,q3,q4 --answers a1,a2,a3,a4 -x 000$i
-        $cmd_tool tagionwallet --create-invoice GENESIS:100000 -x 000$i
+        $cmd_tool tagionwallet --generate-wallet --questions q1,q2,q3,q4 --answers a1,a2,a3,a4 -x $pin
+        $cmd_tool tagionwallet --create-invoice GENESIS:100000 -x $pin
         $cmd_tool tagionboot invoice_file.hibon -o genesis.hibon
         cd ../
         cmd_tool=$(correct_command)

--- a/launch.sh
+++ b/launch.sh
@@ -45,7 +45,7 @@ mode1() {
     rm -f ./shared/*
     for (( i=1; i < $amount; i++ ))
     do
-        $CONSOLE $PRECOMMAND tagionwave --net-mode=local --boot=./shared/boot.hibon --dart-init=true --dart-synchronize=true --dart-path="./data/dart$i.drt" --port=400$i --transaction-port=1080$i --logger-filename=./shared/node-$i.log -N $amount        
+        $CONSOLE $PRECOMMAND tagionwave --net-mode=local --boot=./shared/boot.hibon --dart-init=true --dart-synchronize=true --dart-path="./data/dart$i.drt" --port=400$i --transaction-port=$((10800+$i)) --logger-filename=./shared/node-$i.log -N $amount        
     done
 
     $CONSOLE $PRECOMMAND tagionwave --net-mode=local --boot=./shared/boot.hibon --dart-init=false --dart-synchronize=false --dart-path="./data/dart.drt" --port=4020 --transaction-port=10820 --logger-filename=./shared/node-master.log -N $amount

--- a/launch.sh
+++ b/launch.sh
@@ -45,7 +45,7 @@ mode1() {
     rm -f ./shared/*
     for (( i=1; i < $amount; i++ ))
     do
-        $CONSOLE $PRECOMMAND tagionwave --net-mode=local --boot=./shared/boot.hibon --dart-init=true --dart-synchronize=true --dart-path="./data/dart$i.drt" --port=400$i --transaction-port=$((10800+$i)) --logger-filename=./shared/node-$i.log -N $amount        
+        $CONSOLE $PRECOMMAND tagionwave --net-mode=local --boot=./shared/boot.hibon --dart-init=true --dart-synchronize=true --dart-path="./data/dart$i.drt" --port=$((4000+$i)) --transaction-port=$((10800+$i)) --logger-filename=./shared/node-$i.log -N $amount        
     done
 
     $CONSOLE $PRECOMMAND tagionwave --net-mode=local --boot=./shared/boot.hibon --dart-init=false --dart-synchronize=false --dart-path="./data/dart.drt" --port=4020 --transaction-port=10820 --logger-filename=./shared/node-master.log -N $amount


### PR DESCRIPTION
- Fix limit on maximum 9 nodes when running launch.sh.
- Fix limit on maximum 9 wallets when running create_wallets.sh